### PR TITLE
Fix : Added missing include (fcntl.h), closes #3

### DIFF
--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -52,6 +52,7 @@
 #include <cassert>
 #include <cerrno>
 #include <memory>
+#include <fcntl.h>
 #include <pthread.h>
 #include <semaphore.h>
 #include <signal.h>


### PR DESCRIPTION
Added missing include (in linux OS, fcntl needed for O_CREAT and O_EXCL)