### PR TITLE
Fix : resolve ketama hash collision.

### DIFF
--- a/libmemcached/continuum.hpp
+++ b/libmemcached/continuum.hpp
@@ -43,4 +43,5 @@ struct memcached_continuum_item_st
 {
   uint32_t index;
   uint32_t value;
+  char sort_host[MEMCACHED_MAX_HOST_SORT_LENGTH];
 };

--- a/libmemcached/hosts.cc
+++ b/libmemcached/hosts.cc
@@ -186,7 +186,7 @@ static int continuum_item_cmp(const void *t1, const void *t2)
   /* Why 153? Hmmm... */
   WATCHPOINT_ASSERT(ct1->value != 153);
   if (ct1->value == ct2->value)
-    return 0;
+    return strcmp(ct1->sort_host, ct2->sort_host);
   else if (ct1->value > ct2->value)
     return 1;
   else
@@ -352,6 +352,7 @@ static memcached_return_t update_continuum(memcached_st *ptr)
           for (uint32_t x= 0; x < pointer_per_hash; x++)
           {
             uint32_t value= ketama_server_hash(sort_host, (size_t)sort_host_length, x);
+            memcpy(ptr->ketama.continuum[continuum_index].sort_host, sort_host, sort_host_length);
             ptr->ketama.continuum[continuum_index].index= host_index;
             ptr->ketama.continuum[continuum_index++].value= value;
           }
@@ -359,6 +360,7 @@ static memcached_return_t update_continuum(memcached_st *ptr)
         else
         {
           uint32_t value= hashkit_digest(&ptr->hashkit, sort_host, (size_t)sort_host_length);
+          memcpy(ptr->ketama.continuum[continuum_index].sort_host, sort_host, sort_host_length);
           ptr->ketama.continuum[continuum_index].index= host_index;
           ptr->ketama.continuum[continuum_index++].value= value;
         }
@@ -400,6 +402,7 @@ static memcached_return_t update_continuum(memcached_st *ptr)
           for (uint32_t x = 0; x < pointer_per_hash; x++)
           {
             uint32_t value= ketama_server_hash(sort_host, (size_t)sort_host_length, x);
+            memcpy(ptr->ketama.continuum[continuum_index].sort_host, sort_host, sort_host_length);
             ptr->ketama.continuum[continuum_index].index= host_index;
             ptr->ketama.continuum[continuum_index++].value= value;
           }
@@ -407,6 +410,7 @@ static memcached_return_t update_continuum(memcached_st *ptr)
         else
         {
           uint32_t value= hashkit_digest(&ptr->hashkit, sort_host, (size_t)sort_host_length);
+          memcpy(ptr->ketama.continuum[continuum_index].sort_host, sort_host, sort_host_length);
           ptr->ketama.continuum[continuum_index].index= host_index;
           ptr->ketama.continuum[continuum_index++].value= value;
         }


### PR DESCRIPTION
1. If hash value collide, node whose name string is smaller gets
   ownership of that hash point.

Fix #7 

Review
- [ ] @whchoi83 
- [ ] @jhpark816 
