### PR TITLE
FIX : Get collection attributes(type, readable)

### DIFF
--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -730,6 +730,8 @@ memcached_return_t memcached_get_attrs(memcached_st *ptr,
         }
         else if (strncmp("type", attr_name, sizeof(attr_name)) == 0)
         {
+          word[word_length - 2] = '\0'; // \r
+          word[word_length - 1] = '\0'; // \n
           attrs->type = str_to_type(word, strlen(word));
         }
         else if (strncmp("count", attr_name, sizeof(attr_name)) == 0)
@@ -745,6 +747,10 @@ memcached_return_t memcached_get_attrs(memcached_st *ptr,
           word[word_length - 2] = '\0'; // \r
           word[word_length - 1] = '\0'; // \n
           attrs->overflowaction = str_to_overflowaction(word, strlen(word));
+        }
+        else if (strncmp("readable", attr_name, sizeof(attr_name)) == 0)
+        {
+          attrs->readable = word[0] - '0';
         }
         else if (strncmp("minbkey", attr_name, sizeof(attr_name)) == 0)
         {


### PR DESCRIPTION
collection 속성 중 type과  readable이 제대로 반환되지 않음.

1. type이 항상 null이 반환되는 문제
: type 비교시에 끝 구분 문자열(\r\n)을 고려하지 않아 모든 collection type이 null이 반환됨.
ex) compare(kv == kv\r\n) => false

2. readable 처리 코드가 없어 항상 false가 반환됨

Reviewer
- [ ] @MinWooJin 
- [ ] @jhpark816  